### PR TITLE
画像表示の場所を修正

### DIFF
--- a/resources/views/admin/vegetables/edit.blade.php
+++ b/resources/views/admin/vegetables/edit.blade.php
@@ -41,20 +41,19 @@
                 <textarea id="description" name="description" rows="4" required>{{ $vegetable->description }}</textarea>
             </div>
             <div class="form-group">
-                <label for="image">現在の画像</label>
                 @if ($vegetable->image)
                     <img src="{{ asset('storage/images/' . $vegetable->image) }}" alt="" class="vegetable-image"
-                        id="current-image">
-
+                        id="image-preview">
                 @else
                     <p>画像がありません</p>
+                    <img id="image-preview" class="vegetable-image" style="display:none;">
                 @endif
             </div>
             <div class="form-group">
                 <label for="new_image">新しい画像を選択</label>
                 <input type="file" class="form-control" id="new_image" name="image" onchange="previewImage(event)">
-                <img id="image-preview" class="vegetable-image" style="display:none;">
             </div>
+
             <div class="form-group">
                 <button type="submit" class="update-btn">更新する</button>
             </div>
@@ -75,7 +74,6 @@
                 var output = document.getElementById('image-preview');
                 output.src = reader.result;
                 output.style.display = 'block';
-                document.getElementById('current-image').style.display = 'none';
             };
             reader.readAsDataURL(event.target.files[0]);
         }


### PR DESCRIPTION
### **User description**
・やさい編集時の画像が表示される場所を修正


___

### **PR Type**
Enhancement


___

### **Description**
- 画像プレビューの表示ロジックを修正し、現在の画像ラベルを削除
- 画像がない場合のプレースホルダー画像を追加
- JavaScriptのプレビュー機能を調整し、より直感的なUIを実現


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edit.blade.php</strong><dd><code>画像プレビュー機能の改善とUI調整</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/views/admin/vegetables/edit.blade.php

<li>画像プレビューの表示ロジックを修正<br> <li> 現在の画像ラベルを削除<br> <li> 画像がない場合のプレースホルダー画像を追加<br> <li> JavaScriptのプレビュー機能を調整<br>


</details>


  </td>
  <td><a href="https://github.com/amakai0406/agriculture-blog/pull/33/files#diff-b68a867a8193f09bb370817737f31fa6f9c863f8a15a88791e5155d68dec7619">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

