### PR TITLE
参加人数のロジック修正

### DIFF
--- a/resources/views/admin/layouts/index.blade.php
+++ b/resources/views/admin/layouts/index.blade.php
@@ -22,7 +22,7 @@
                 <tr>
                     <td>{{ $event->title }}</td>
                     <td>{{ $event->event_date }}</td>
-                    <td>{{ $event->reserved_participants }}人</td>
+                    <td>{{ $event->participants_count }}人</td>
                 </tr>
             @endforeach
         </tbody>


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- イベントの参加者数を計算するロジックを修正し、確認済みの予約のみをカウントするように変更しました。
- Bladeテンプレートでの参加者数の表示を新しいロジックに対応させました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DashboardController.php</strong><dd><code>Refactor event participant counting logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/Http/Controllers/admin/DashboardController.php

<li>Updated the query logic for fetching event data.<br> <li> Changed the join condition to filter only confirmed reservations.<br> <li> Simplified the selection of columns and aggregation.<br>


</details>


  </td>
  <td><a href="https://github.com/amakai0406/agriculture-blog/pull/43/files#diff-8c3bb7d801f803248b165c03ff1723e696f7739ac643abe24cb214b5156f21a5">+7/-24</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.blade.php</strong><dd><code>Update participant count display logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

resources/views/admin/layouts/index.blade.php

- Updated the variable used to display participant count.



</details>


  </td>
  <td><a href="https://github.com/amakai0406/agriculture-blog/pull/43/files#diff-950cddf46563255a590895615da37aac45c0491baa164764a3621013d1696f8a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

